### PR TITLE
tag date in version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - scopatz
+    - dougalsutherland

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: {{ version }}.{{ date }}
 
 source:
   fn: {{ name }}-{{ date }}-{{ version }}.tar.gz


### PR DESCRIPTION
Apparently the date is actually an important component of the version, since [symbols are sometimes added](https://abi-laboratory.pro/tracker/timeline/libedit/) in versions that are otherwise just `3.1`.

This would change the version name to e.g. `3.1.20170329`, which would allow for proper if somewhat verbose pinning. (See also https://github.com/conda-forge/conda-forge.github.io/issues/478.)