### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -4,16 +4,31 @@
 
 jobs:
 - job: linux
-  pool: {vmImage: ubuntu-16.04}
+  pool:
+    vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_: {CONFIG: linux_, UPLOAD_PACKAGES: 'True', DOCKER_IMAGE: condaforge/linux-anvil-comp7}
-      linux_aarch64_: {CONFIG: linux_aarch64_, UPLOAD_PACKAGES: 'True', DOCKER_IMAGE: condaforge/linux-anvil-aarch64}
-      linux_ppc64le_: {CONFIG: linux_ppc64le_, UPLOAD_PACKAGES: 'True', DOCKER_IMAGE: condaforge/linux-anvil-ppc64le}
+      linux_:
+        CONFIG: linux_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
     maxParallel: 8
   timeoutInMinutes: 360
 
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+    displayName: Manage disk space
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
@@ -25,6 +40,7 @@ jobs:
   - script: |
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -4,10 +4,13 @@
 
 jobs:
 - job: osx
-  pool: {vmImage: macOS-10.14}
+  pool:
+    vmImage: macOS-10.14
   strategy:
     matrix:
-      osx_: {CONFIG: osx_, UPLOAD_PACKAGES: 'True'}
+      osx_:
+        CONFIG: osx_
+        UPLOAD_PACKAGES: 'True'
     maxParallel: 8
   timeoutInMinutes: 360
 
@@ -17,6 +20,7 @@ jobs:
       export CI=azure
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @djsutherland @scopatz
+* @djsutherland @mingwandroid @scopatz

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -30,11 +30,12 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "libedit-feedstock"
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="libedit-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -13,6 +13,10 @@ PROVIDER_DIR="$(basename $THISDIR)"
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -63,12 +67,14 @@ docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
+           -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -47,10 +47,10 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "libedit-feedstock"
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="libedit-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@ About libedit
 
 Home: http://thrysoee.dk/editline/
 
-Package license: NetBSD
+Package license: BSD-2-Clause
 
-Feedstock license: BSD 3-Clause
+Feedstock license: BSD-3-Clause
 
-Summary: Command line editor library provides generic line editing, history, and tokenization
-functions, similar to those found in GNU Readline.
+Summary: Editline Library (libedit)
 
-
+This is an autotool- and libtoolized port of the NetBSD Editline library
+(libedit). This Berkeley-style licensed command line editor library provides
+generic line editing, history, and tokenization functions, similar to those
+found in GNU Readline
 
 
 Current build status
@@ -165,5 +167,6 @@ Feedstock Maintainers
 =====================
 
 * [@djsutherland](https://github.com/djsutherland/)
+* [@mingwandroid](https://github.com/mingwandroid/)
 * [@scopatz](https://github.com/scopatz/)
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ set -ex
 autoreconf -f
 ./configure --prefix=${PREFIX} \
             --host=${HOST} \
+            --disable-static \
             CFLAGS="${CFLAGS} -I${PREFIX}/include" \
             LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 make -j ${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # no info available.  Guessing at x.x.  Change if you know better.
     - {{ pin_subpackage('libedit', max_pin='x.x') }}
@@ -40,6 +40,7 @@ test:
   commands:
     - test -f $PREFIX/lib/libedit.dylib  # [osx]
     - test -f $PREFIX/lib/libedit.so     # [linux]
+    - test ! -f $PREFIX/lib/libedit.a   # [unix]
 
 about:
   home: http://thrysoee.dk/editline/


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
